### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-##Reader
+## Reader
 ---
 基于`Core Text`实现的iOS客户端的`电子书阅读器`。</br>
 **支持ePub与text格式**
 
 ---
 
-###2016.11.22 更新
+### 2016.11.22 更新
 - **添加对ePub格式电子书的阅读排版支持**
 - **添加对ePub格式电子书的图片显示支持**
 
@@ -23,8 +23,8 @@
 5. 支持`txt`与`ePub`格式的电子书文件
 
 ---
-##安装与使用
-###安装
+## 安装与使用
+### 安装
 1. 将`Reader`目录下的所有文件都添加到工程中</br>
 2. 由于解压`ePub`文件，需要用到开源的`.c文件`用于解压缩。所以使用时如果项目中有`.pch文件`参考本项目中`.pch`文件写法</br>
 ```c
@@ -34,7 +34,7 @@
 ```
 3.需要导入`libz.tbd`库
 
-###使用
+### 使用
 text文件</br>
 ```objective-c
    LSYReadPageViewController *pageView = [[LSYReadPageViewController alloc] init];
@@ -52,8 +52,8 @@ ePub文件</br>
     [self presentViewController:pageView animated:YES completion:nil];
 ```
 
-###提示
+### 提示
 **之前安装过的下载最新版，应把之前安装的卸载后再安装**
 
-###说明
+### 说明
 对于有图片和定制样式的epub文件只显示纯文本信息，因为对epub每个章节的html文件直接转成字符串来处理，css样式与epub自带的本地图片没有做处理。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
