### PR TITLE
增加对包含中文的URL支持，修复在Present出来的VC里Present阅读器后点击返回按钮返回错误的BUG

### DIFF
--- a/LSYReader/LSYReader/Reader/Core/LSYReadUtilites.h
+++ b/LSYReader/LSYReader/Reader/Core/LSYReadUtilites.h
@@ -12,7 +12,6 @@
 +(void)separateChapter:(NSMutableArray **)chapters content:(NSString *)content;
 +(NSString *)encodeWithURL:(NSURL *)url;
 +(UIButton *)commonButtonSEL:(SEL)sel target:(id)target;
-+(UIViewController *)getCurrentVC;
 +(void)showAlertTitle:(NSString *)title content:(NSString *)string;
 /**
  * ePub格式处理

--- a/LSYReader/LSYReader/Reader/Core/LSYReadUtilites.m
+++ b/LSYReader/LSYReader/Reader/Core/LSYReadUtilites.m
@@ -84,37 +84,6 @@
     [button addTarget:target action:sel forControlEvents:UIControlEventTouchUpInside];
     return button;
 }
-+(UIViewController *)getCurrentVC
-{
-    UIViewController *result = nil;
-    
-    
-    UIWindow * window = [[UIApplication sharedApplication] keyWindow];
-    if (window.windowLevel != UIWindowLevelNormal)
-    {
-        NSArray *windows = [[UIApplication sharedApplication] windows];
-        for(UIWindow * tmpWin in windows)
-        {
-            if (tmpWin.windowLevel == UIWindowLevelNormal)
-            {
-                window = tmpWin;
-                break;
-            }
-        }
-    }
-    
-    
-    UIView *frontView = [[window subviews] objectAtIndex:0];
-    id nextResponder = [frontView nextResponder];
-    
-    
-    if ([nextResponder isKindOfClass:[UIViewController class]])
-        result = nextResponder;
-    else
-        result = window.rootViewController;
-    
-    return result;
-}
 +(void)showAlertTitle:(NSString *)title content:(NSString *)string
 {
 #pragma clang diagnostic push

--- a/LSYReader/LSYReader/Reader/Model/LSYChapterModel.m
+++ b/LSYReader/LSYReader/Reader/Model/LSYChapterModel.m
@@ -26,12 +26,13 @@
 }
 +(id)chapterWithEpub:(NSString *)chapterpath title:(NSString *)title imagePath:(NSString *)path
 {
+    NSString * tmp=[chapterpath URLDecodedString];
     LSYChapterModel *model = [[LSYChapterModel alloc] init];
     model.title = title;
     model.epubImagePath = path;
     model.type = ReaderEpub;
-    model.chapterpath = chapterpath;
-    NSString* html = [[NSString alloc] initWithData:[NSData dataWithContentsOfURL:[NSURL fileURLWithPath:chapterpath]] encoding:NSUTF8StringEncoding];
+    model.chapterpath = tmp;
+    NSString* html = [[NSString alloc] initWithData:[NSData dataWithContentsOfURL:[NSURL fileURLWithPath:tmp]] encoding:NSUTF8StringEncoding];
     model.html = html;
     model.content = [html stringByConvertingHTMLToPlainText];
     [model parserEpubToDictionary];
@@ -49,7 +50,8 @@
         if ([scanner scanString:@"<img>" intoString:NULL]) {
             NSString *img;
             [scanner scanUpToString:@"</img>" intoString:&img];
-            NSString *imageString = [self.epubImagePath stringByAppendingPathComponent:img];
+            NSString *temp = [self.epubImagePath stringByAppendingPathComponent:img];
+            NSString * imageString=[temp URLDecodedString];
             UIImage *image = [UIImage imageWithContentsOfFile:imageString];
             CGSize size = CGSizeMake((ScreenSize.width-LeftSpacing-RightSpacing), (ScreenSize.width-LeftSpacing-RightSpacing)/(ScreenSize.height-TopSpacing-BottomSpacing)*image.size.width);
             if (size.height>(ScreenSize.height-TopSpacing-BottomSpacing-20)) {

--- a/LSYReader/LSYReader/Reader/Third/NSString+HTML.h
+++ b/LSYReader/LSYReader/Reader/Third/NSString+HTML.h
@@ -43,4 +43,6 @@
 // DEPRECIATED - Please use NSString stringByConvertingHTMLToPlainText
 - (NSString *)stringByStrippingTags; 
 
+-(NSString *)URLEncodedString;
+-(NSString *)URLDecodedString;
 @end

--- a/LSYReader/LSYReader/Reader/Third/NSString+HTML.m
+++ b/LSYReader/LSYReader/Reader/Third/NSString+HTML.m
@@ -361,4 +361,23 @@
 	
 }
 
+- (NSString *)URLEncodedString
+{
+    NSString *encodedString = (NSString *)
+    CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
+                                                              (CFStringRef)self,
+                                                              (CFStringRef)@"!$&'()*+,-./:;=?@_~%#[]",
+                                                              NULL,
+                                                              kCFStringEncodingUTF8));
+    return encodedString;
+}
+
+-(NSString *)URLDecodedString
+{
+    NSString *decodedString=(__bridge_transfer NSString *)CFURLCreateStringByReplacingPercentEscapesUsingEncoding(NULL, (__bridge CFStringRef)self, CFSTR(""), CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding));
+    
+    return decodedString;
+}
+
+
 @end

--- a/LSYReader/LSYReader/Reader/View/LSYTopMenuView.m
+++ b/LSYReader/LSYReader/Reader/View/LSYTopMenuView.m
@@ -61,7 +61,26 @@
 }
 -(void)backView
 {
-    [[LSYReadUtilites getCurrentVC] dismissViewControllerAnimated:YES completion:nil];
+    [[self topViewController] dismissViewControllerAnimated:YES completion:nil];
+}
+- (UIViewController *)topViewController {
+    UIViewController *resultVC;
+    resultVC = [self _topViewController:[[UIApplication sharedApplication].keyWindow rootViewController]];
+    while (resultVC.presentedViewController) {
+        resultVC = [self _topViewController:resultVC.presentedViewController];
+    }
+    return resultVC;
+}
+
+- (UIViewController *)_topViewController:(UIViewController *)vc {
+    if ([vc isKindOfClass:[UINavigationController class]]) {
+        return [self _topViewController:[(UINavigationController *)vc topViewController]];
+    }else if ([vc isKindOfClass:[UITabBarController class]]) {
+        return [self _topViewController:[(UITabBarController *)vc selectedViewController]];
+    } else {
+        return vc;
+    }
+    return nil;
 }
 -(void)layoutSubviews
 {


### PR DESCRIPTION
在使用这个库的时候发现如果xhtml标题和图片名称里如果包含中文或者中文符号就会读取内容失败，于是我增加了对URL编码的中文支持；如果在present出来的VC里present阅读器，在TOPMenuView里点返回获取的CurrentVC不对，修改了获取方式，从window的最底层遍历到最上层的VC，用最上层VCdismiss，可以正确的返回到上一级VC