### PR TITLE
bug - 图片计算高度错误导致的图片展示比例压缩

### DIFF
--- a/LSYReader/LSYReader.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/LSYReader/LSYReader.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/LSYReader/LSYReader/Reader/Model/LSYChapterModel.m
+++ b/LSYReader/LSYReader/Reader/Model/LSYChapterModel.m
@@ -51,10 +51,15 @@
             [scanner scanUpToString:@"</img>" intoString:&img];
             NSString *imageString = [self.epubImagePath stringByAppendingPathComponent:img];
             UIImage *image = [UIImage imageWithContentsOfFile:imageString];
-            CGSize size = CGSizeMake((ScreenSize.width-LeftSpacing-RightSpacing), (ScreenSize.width-LeftSpacing-RightSpacing)/(ScreenSize.height-TopSpacing-BottomSpacing)*image.size.width);
-            if (size.height>(ScreenSize.height-TopSpacing-BottomSpacing-20)) {
-                size.height = ScreenSize.height-TopSpacing-BottomSpacing-20
-                ;
+            
+            CGFloat width = ScreenSize.width - LeftSpacing - RightSpacing;
+            CGFloat height = ScreenSize.height - TopSpacing - BottomSpacing;
+            CGFloat scale = image.size.width / width;
+            CGFloat realHeight = image.size.height / scale;
+            CGSize size = CGSizeMake(width, realHeight);
+
+            if (size.height > (height - 20)) {
+                size.height = height - 20;
             }
             [array addObject:@{@"type":@"img",@"content":imageString?imageString:@"",@"width":@(size.width),@"height":@(size.height)}];
             //存储图片信息


### PR DESCRIPTION
LSYChapterModel.m 类的 parserEpubToDictionary 方法中 根据显示比例计算图片高度时 width 和 height 写错了