### PR TITLE
bug - 修复 epub 多图片渲染出现空白页 bug

### DIFF
--- a/LSYReader/LSYReader/Reader/LSYReadView.m
+++ b/LSYReader/LSYReader/Reader/LSYReadView.m
@@ -288,7 +288,7 @@
             UIImage *image = [UIImage imageWithContentsOfFile:imageData.url];
             CFRange range = CTFrameGetVisibleStringRange(_frameRef);
             
-            if (image&&(range.location<=imageData.position&&imageData.position<=(range.length + range.location))) {
+            if (image&&(range.location<=imageData.position&&imageData.position<(range.length + range.location))) {
                 [self fillImagePosition:imageData];
                 if (imageData.position==(range.length + range.location)) {
                     if ([self showImage]) {

--- a/LSYReader/LSYReader/Reader/Model/LSYChapterModel.m
+++ b/LSYReader/LSYReader/Reader/Model/LSYChapterModel.m
@@ -65,7 +65,11 @@
             //存储图片信息
             LSYImageData *imageData = [[LSYImageData alloc] init];
             imageData.url = imageString?imageString:@"";
-            imageData.position = newString.length;
+            if (imageArray.count) {
+                imageData.position = newString.length + imageArray.count;
+            } else {
+                imageData.position = newString.length;
+            }
 //            imageData.imageRect = CGRectMake(0, 0, size.width, size.height);
             [imageArray addObject:imageData];
             


### PR DESCRIPTION
原因是 LSYChapterModel 类中的 imageData.position 赋值错误，没有添加图片的占位位置，只添加了文字的 length ，还有 LSYReadView 的 drawRect 方法中的渲染图片的条件错误